### PR TITLE
Add a role for provisioning IAM roles that can read particular certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ bucket for SSL certificates in the COOL DNS account.
 | certificatesbucketreadonly_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where certboto-docker certificates are stored. | string | `Allows read-only access to the S3 bucket where certboto-docker certificates are stored.` | no |
 | certificatesbucketreadonly_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access the S3 bucket where certboto-docker certificates are stored. | string | `CertificatesBucketReadOnly` | no |
 | provisionaccount_role_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the DNS account. | string | `ProvisionAccount` | no |
-| provisioncertificatesbucket_role_description | The description to associate with the IAM policy that allows provisioning of the S3 bucket where certboto-docker certificates are stored. | string | `Allows provisioning of the S3 bucket where certboto-docker certificates are stored.` | no |
-| provisioncertificatesbucket_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows provisioning of the S3 bucket where certboto-docker certificates are stored. | string | `ProvisionCertificatesBucket` | no |
+| provisioncertificatereadroles_role_description | The description to associate with the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can read selected certificates in the certificates bucket in the DNS account. | string | `Allows provisioning of IAM roles that can read selected certificates in the certificates bucket in the DNS account.` | no |
+| provisioncertificatereadroles_role_name | The name to assign the IAM role (as well as the corresponding policy) with the ability to provision IAM roles that can read selected certificates in the certificates bucket in the DNS account. | string | `ProvisionCertificateReadRoles` | no |
+| provisioncertificatesbucket_policy_description | The description to associate with the IAM policy that allows provisioning of the S3 bucket where certboto-docker certificates are stored. | string | `Allows provisioning of the S3 bucket where certboto-docker certificates are stored.` | no |
+| provisioncertificatesbucket_policy_name | The name to assign the IAM policy that allows provisioning of the S3 bucket where certboto-docker certificates are stored. | string | `ProvisionCertificatesBucket` | no |
 | tags | Tags to apply to all AWS resources provisioned. | map(string) | `{}` | no |
 | users_account_id | The ID of the users account. | string | | yes |
 
@@ -31,6 +33,7 @@ bucket for SSL certificates in the COOL DNS account.
 | certificates_bucket_id | The ID of the S3 bucket where certboto-docker certificates will be stored. |
 | certificatesbucketfullaccess_role_arn | The ARN of the IAM role that allows full access to the certboto-docker certificates bucket in the DNS account. |
 | certificatesbucketreadonly_role_arn | The ARN of the IAM role that allows read-only access to the certboto-docker certificates bucket in the DNS account. |
+| provisioncertificatereadroles_role_arn | The ARN of the IAM role with the ability to provision IAM roles that can read selected certificates in the certificates bucket in the DNS account. |
 | provisioncertificatesbucket_policy_arn | The ARN of the IAM policy that allows provisioning of the certboto-docker certificates bucket in the DNS account. |
 
 ## Contributing ##

--- a/caller_identity.tf
+++ b/caller_identity.tf
@@ -1,0 +1,6 @@
+# ------------------------------------------------------------------------------
+# We can get the account ID of the DNS account from the provider's
+# caller identity.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "dns" {
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "certificatesbucketreadonly_role_arn" {
   description = "The ARN of the IAM role that allows read-only access to the certboto-docker certificates bucket in the DNS account."
 }
 
+output "provisioncertificatereadroles_role_arn" {
+  value       = aws_iam_role.provisioncertificatereadroles_role.arn
+  description = "The ARN of the IAM role with the ability to provision IAM roles that can read selected certificates in the certificates bucket in the DNS account."
+}
+
 output "provisioncertificatesbucket_policy_arn" {
   value       = aws_iam_policy.provisioncertificatesbucket_policy.arn
   description = "The ARN of the IAM policy that allows provisioning of the certboto-docker certificates bucket in the DNS account."

--- a/provisioncertificatereadroles_policy.tf
+++ b/provisioncertificatereadroles_policy.tf
@@ -1,0 +1,46 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that gives the ability to create IAM roles
+# that can read selected certificates in the certificate bucket in the
+# DNS account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "provisioncertificatereadroles_doc" {
+  statement {
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
+      "iam:PutRolePolicy",
+      "iam:TagRole",
+      "iam:UpdateRole"
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.dns.account_id}:role/CertificateReadOnly-*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "iam:CreatePolicy",
+      "iam:DeletePolicy",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:ListPolicyVersions"
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.dns.account_id}:policy/CertificateReadOnly-*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "provisioncertificatereadroles_policy" {
+  description = var.provisioncertificatereadroles_role_description
+  name        = var.provisioncertificatereadroles_role_name
+  policy      = data.aws_iam_policy_document.provisioncertificatereadroles_doc.json
+}

--- a/provisioncertificatereadroles_role.tf
+++ b/provisioncertificatereadroles_role.tf
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that is allowed to itself create IAM roles that
+# can read selected certificates in the certificate bucket in the DNS
+# account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "provisioncertificatereadroles_role" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  description        = var.provisioncertificatereadroles_role_description
+  name               = var.provisioncertificatereadroles_role_name
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "provisioncertificatereadroles_policy_attachment" {
+  policy_arn = aws_iam_policy.provisioncertificatereadroles_policy.arn
+  role       = aws_iam_role.provisioncertificatereadroles_role.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,16 @@ variable "provisionaccount_role_name" {
   default     = "ProvisionAccount"
 }
 
+variable "provisioncertificatereadroles_role_description" {
+  description = "The description to associate with the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can read selected certificates in the certificates bucket in the DNS account."
+  default     = "Allows provisioning of IAM roles that can read selected certificates in the certificates bucket in the DNS account."
+}
+
+variable "provisioncertificatereadroles_role_name" {
+  description = "The name to assign the IAM role (as well as the corresponding policy) with the ability to provision IAM roles that can read selected certificates in the certificates bucket in the DNS account."
+  default     = "ProvisionCertificateReadRoles"
+}
+
 variable "provisioncertificatesbucket_policy_description" {
   description = "The description to associate with the IAM policy that allows provisioning of the S3 bucket where certboto-docker certificates are stored."
   default     = "Allows provisioning of the S3 bucket where certboto-docker certificates are stored."


### PR DESCRIPTION
## 🗣 Description

In this pull request I add a role for provisioning IAM roles that can read particular certificates in the certificates bucket in the DNS account.

## 💭 Motivation and Context

We require such a role to ensure that all such roles use a particular naming scheme.

## 🧪 Testing

I deployed these changes to production and verified that all pre-commit hooks passed.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
