### PR TITLE
Add missing permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.8'
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2-beta
         with:
           go-version: '1.13.8'
       - name: Cache pip test requirements

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: cisagov/setup-env-github-action@develop
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
@@ -67,9 +67,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade \
-                      --requirement requirements-test.txt
-      - name: Run linters on all files
+          pip install --upgrade -r requirements-test.txt
+      - name: Run pre-commit on all files
         run: pre-commit run --all-files
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade -r requirements-test.txt
+          pip install --upgrade --requirement requirements-test.txt
       - name: Run pre-commit on all files
         run: pre-commit run --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,20 +10,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
-
+          python-version: 3.8
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit
           key: "${{ runner.os }}-pre-commit-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
-
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
@@ -33,11 +29,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements-test.txt
-
       - name: Run pre-commit on all files
         run: pre-commit run --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,6 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - name: Cache pre-commit hooks
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pre-commit
-          key: "${{ runner.os }}-pre-commit-\
-            ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
@@ -29,6 +23,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: "${{ runner.os }}-pre-commit-\
+            ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.22.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.18.0
+    rev: v1.20.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.25.1
+    rev: v1.26.2
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.3
+    rev: v1.9.4
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -71,7 +71,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.1.1a5
+    rev: v4.2.0
     hooks:
       - id: ansible-lint
         # files: molecule/default/playbook.yml
@@ -81,7 +81,7 @@ repos:
       - id: terraform_fmt
       - id: terraform_validate_no_variables
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,31 @@ eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 ```
 
-For Linux (or on the Mac, if you don't want to use `brew`) you can use
+For Linux, Windows Subsystem for Linux (WSL), or on the Mac (if you
+don't want to use `brew`) you can use
 [pyenv/pyenv-installer](https://github.com/pyenv/pyenv-installer) to
-install the necessary tools.  When you are finished you will need to
-add the same two lines above to your profile.
+install the necessary tools. Before running this ensure that you have
+installed the prerequisites for your platform according to the
+[`pyenv` wiki
+page](https://github.com/pyenv/pyenv/wiki/common-build-problems).
+
+On WSL you should treat your platform as whatever Linux distribution
+you've chosen to install.
+
+Once you have installed `pyenv` you will need to add the following
+lines to your `.bashrc`:
+
+```bash
+export PATH="$PATH:$HOME/.pyenv/bin"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+```
+
+If you are using a shell other than `bash` you should follow the
+instructions that the `pyenv-installer` script outputs.
+
+You will need to reload your shell for these changes to take effect so
+you can begin to use `pyenv`.
 
 For a list of Python versions that are already installed and ready to
 use with `pyenv`, use the command `pyenv versions`.  To see a list of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ commands:
 cd skeleton-generic
 pyenv virtualenv <python_version_to_use> skeleton-generic
 pyenv local skeleton-generic
-pip install -r requirements-dev.txt
+pip install --requirement requirements-dev.txt
 ```
 
 #### Installing the pre-commit hook ####

--- a/README.md
+++ b/README.md
@@ -29,12 +29,11 @@ bucket for SSL certificates in the COOL DNS account.
 
 | Name | Description |
 |------|-------------|
-| certificates_bucket_arn | The ARN of the S3 bucket where certboto-docker certificates will be stored. |
-| certificates_bucket_id | The ID of the S3 bucket where certboto-docker certificates will be stored. |
-| certificatesbucketfullaccess_role_arn | The ARN of the IAM role that allows full access to the certboto-docker certificates bucket in the DNS account. |
-| certificatesbucketreadonly_role_arn | The ARN of the IAM role that allows read-only access to the certboto-docker certificates bucket in the DNS account. |
-| provisioncertificatereadroles_role_arn | The ARN of the IAM role with the ability to provision IAM roles that can read selected certificates in the certificates bucket in the DNS account. |
-| provisioncertificatesbucket_policy_arn | The ARN of the IAM policy that allows provisioning of the certboto-docker certificates bucket in the DNS account. |
+| certificates_bucket | The S3 bucket where certboto-docker certificates will be stored. |
+| certificatesbucketfullaccess_role | The IAM role that allows full access to the certboto-docker certificates bucket in the DNS account. |
+| certificatesbucketreadonly_role | The IAM role that allows read-only access to the certboto-docker certificates bucket in the DNS account. |
+| provisioncertificatereadroles_role | The IAM role with the ability to provision IAM roles that can read selected certificates in the certificates bucket in the DNS account. |
+| provisioncertificatesbucket_policy | The IAM policy that allows provisioning of the certboto-docker certificates bucket in the DNS account. |
 
 ## Contributing ##
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,29 +1,24 @@
-output "certificates_bucket_arn" {
-  value       = aws_s3_bucket.certificates.arn
-  description = "The ARN of the S3 bucket where certboto-docker certificates will be stored."
+output "certificates_bucket" {
+  value       = aws_s3_bucket.certificates
+  description = "The S3 bucket where certboto-docker certificates will be stored."
 }
 
-output "certificates_bucket_id" {
-  value       = aws_s3_bucket.certificates.id
-  description = "The ID of the S3 bucket where certboto-docker certificates will be stored."
+output "certificatesbucketfullaccess_role" {
+  value       = aws_iam_role.certificatesbucketfullaccess_role
+  description = "The IAM role that allows full access to the certboto-docker certificates bucket in the DNS account."
 }
 
-output "certificatesbucketfullaccess_role_arn" {
-  value       = aws_iam_role.certificatesbucketfullaccess_role.arn
-  description = "The ARN of the IAM role that allows full access to the certboto-docker certificates bucket in the DNS account."
+output "certificatesbucketreadonly_role" {
+  value       = aws_iam_role.certificatesbucketreadonly_role
+  description = "The IAM role that allows read-only access to the certboto-docker certificates bucket in the DNS account."
 }
 
-output "certificatesbucketreadonly_role_arn" {
-  value       = aws_iam_role.certificatesbucketreadonly_role.arn
-  description = "The ARN of the IAM role that allows read-only access to the certboto-docker certificates bucket in the DNS account."
+output "provisioncertificatereadroles_role" {
+  value       = aws_iam_role.provisioncertificatereadroles_role
+  description = "The IAM role with the ability to provision IAM roles that can read selected certificates in the certificates bucket in the DNS account."
 }
 
-output "provisioncertificatereadroles_role_arn" {
-  value       = aws_iam_role.provisioncertificatereadroles_role.arn
-  description = "The ARN of the IAM role with the ability to provision IAM roles that can read selected certificates in the certificates bucket in the DNS account."
-}
-
-output "provisioncertificatesbucket_policy_arn" {
-  value       = aws_iam_policy.provisioncertificatesbucket_policy.arn
-  description = "The ARN of the IAM policy that allows provisioning of the certboto-docker certificates bucket in the DNS account."
+output "provisioncertificatesbucket_policy" {
+  value       = aws_iam_policy.provisioncertificatesbucket_policy
+  description = "The IAM policy that allows provisioning of the certboto-docker certificates bucket in the DNS account."
 }

--- a/provisioncertificatereadroles_policy.tf
+++ b/provisioncertificatereadroles_policy.tf
@@ -18,6 +18,7 @@ data "aws_iam_policy_document" "provisioncertificatereadroles_doc" {
       "iam:ListInstanceProfilesForRole",
       "iam:PutRolePolicy",
       "iam:TagRole",
+      "iam:UpdateAssumeRolePolicy",
       "iam:UpdateRole"
     ]
     resources = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
--r requirements-test.txt
+--requirement requirements-test.txt
 ipython


### PR DESCRIPTION
## 🗣 Description

I found a terraform (re)apply (for the example code in [cisagov/freeipa-master-tf-module](https://cisagov/freeipa-master-tf-module)) to be failing because Terraform wanted to simply update the assume role policy in place but lacked this permission.  The permission is added in commit e0103a3.

I took the opportunity to also pull in upstream changes and, in commit fb7119c, change the outputs to resources instead of ARNs and IDs.

## 💭 Motivation and Context

The permission I added is necessary for this deployment to function smoothly when performing a terraform (re)apply.

## 🧪 Testing

I have deployed these changes to production and verified that the only change Terraform wanted to make was to add the missing permission.  I also successfully deployed the example code in [cisagov/freeipa-master-tf-module](https://cisagov/freeipa-master-tf-module) with this change.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
