### PR TITLE
Add the UpdateRoleDescription permission

### DIFF
--- a/provisioncertificatereadroles_policy.tf
+++ b/provisioncertificatereadroles_policy.tf
@@ -19,7 +19,8 @@ data "aws_iam_policy_document" "provisioncertificatereadroles_doc" {
       "iam:PutRolePolicy",
       "iam:TagRole",
       "iam:UpdateAssumeRolePolicy",
-      "iam:UpdateRole"
+      "iam:UpdateRole",
+      "iam:UpdateRoleDescription",
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.dns.account_id}:role/CertificateReadOnly-*"
@@ -32,7 +33,7 @@ data "aws_iam_policy_document" "provisioncertificatereadroles_doc" {
       "iam:DeletePolicy",
       "iam:GetPolicy",
       "iam:GetPolicyVersion",
-      "iam:ListPolicyVersions"
+      "iam:ListPolicyVersions",
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.dns.account_id}:policy/CertificateReadOnly-*"


### PR DESCRIPTION
## 🗣 Description

In `terraform` (re)`apply`ing cisagov/cool-sharedservices-freeipa, I found that this permission is sometimes required.  In the hope of being proactive, I perused the list of `Update*` IAM permissions  [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_identityandaccessmanagement.html)
and I think this is the only one that needs to be added here.

## 💭 Motivation and Context

I need to be able to `terraform` (re)`apply` cleanly.

## 🧪 Testing

I deployed these changes to production and verified that I no longer have the issue.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
