### PR TITLE
Specify string type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,25 @@ jobs:
       - uses: actions/setup-go@v2-beta
         with:
           go-version: '1.13.8'
+      - name: Store installed Python version
+        run: |
+          echo "::set-env name=PY_VERSION::"\
+          "$(python -c "import platform;print(platform.python_version())")"
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: "${{ runner.os }}-pip-test-\
+          key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
+            ${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
           path: ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: "${{ runner.os }}-pre-commit-\
+          key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Cache curl downloads
         uses: actions/cache@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.mypy_cache
 __pycache__
 .python-version
 .terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.0.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -74,7 +74,7 @@ repos:
     rev: v4.2.0
     hooks:
       - id: ansible-lint
-        # files: molecule/default/playbook.yml
+      # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.12.0
     hooks:
@@ -88,3 +88,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.761
+    hooks:
+      - id: mypy

--- a/variables.tf
+++ b/variables.tf
@@ -5,10 +5,12 @@
 # ------------------------------------------------------------------------------
 
 variable "certificates_bucket_name" {
+  type        = string
   description = "The name to use for the S3 bucket that will store the certboto-docker certificates."
 }
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account."
 }
 
@@ -19,51 +21,61 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "certificatesbucketfullaccess_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows full access to the S3 bucket where certboto-docker certificates are stored."
   default     = "Allows full access to the S3 bucket where certboto-docker certificates are stored."
 }
 
 variable "certificatesbucketfullaccess_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows full access to the S3 bucket where certboto-docker certificates are stored."
   default     = "CertificatesBucketFullAccess"
 }
 
 variable "certificatesbucketreadonly_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where certboto-docker certificates are stored."
   default     = "Allows read-only access to the S3 bucket where certboto-docker certificates are stored."
 }
 
 variable "certificatesbucketreadonly_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where certboto-docker certificates are stored."
   default     = "CertificatesBucketReadOnly"
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name of the IAM role that allows sufficient permissions to provision all AWS resources in the DNS account."
   default     = "ProvisionAccount"
 }
 
 variable "provisioncertificatereadroles_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can read selected certificates in the certificates bucket in the DNS account."
   default     = "Allows provisioning of IAM roles that can read selected certificates in the certificates bucket in the DNS account."
 }
 
 variable "provisioncertificatereadroles_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) with the ability to provision IAM roles that can read selected certificates in the certificates bucket in the DNS account."
   default     = "ProvisionCertificateReadRoles"
 }
 
 variable "provisioncertificatesbucket_policy_description" {
+  type        = string
   description = "The description to associate with the IAM policy that allows provisioning of the S3 bucket where certboto-docker certificates are stored."
   default     = "Allows provisioning of the S3 bucket where certboto-docker certificates are stored."
 }
 
 variable "provisioncertificatesbucket_policy_name" {
+  type        = string
   description = "The name to assign the IAM policy that allows provisioning of the S3 bucket where certboto-docker certificates are stored."
   default     = "ProvisionCertificatesBucket"
 }


### PR DESCRIPTION
## 🗣 Description

Previously string was the default type, but this is [no longer the case](https://www.terraform.io/docs/configuration/variables.html#type-constraints).

I ran into a case today where this mattered.  I used `set([var.string_value])` in a `for_each`, and Terraform rejected the syntax since it couldn't verify that the output would be a set of strings.  Adding the string type declaration to the variable fixed the issue.

## 💭 Motivation and Context

This change makes the code more correct, and it will avoid subtle errors like the one I saw today.

## 🧪 Testing

I ran a `terraform apply` and verified that nothing needed to be changed.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
