### PR TITLE
Remove email address check on Users account

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -26,9 +26,9 @@ locals {
     x.id if x.name == "DNS"
   ][0]
 
-  # Find the Users account by name and email.
+  # Find the Users account by name.
   users_account_id = [
     for x in data.aws_organizations_organization.cool.accounts :
-    x.id if x.name == "Users" && length(regexall("2020", x.email)) > 0
+    x.id if x.name == "Users"
   ][0]
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes a now-unnecessary check for "2020" in the email address of the Users account.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is no longer needed now that we have deleted the old, incorrectly set-up Users account from our AWS organization that prompted that check in the first place.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this in the Terraform console to ensure that only the correct Users account ID is found.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
